### PR TITLE
add filename for kml response

### DIFF
--- a/src/tomato/api/views.py
+++ b/src/tomato/api/views.py
@@ -525,6 +525,8 @@ def semantic_query(request, format='json'):
     r = response.StreamingHttpResponse(ret, content_type=content_type)
     if format == 'poi':
         r['Content-Disposition'] = 'filename=SearchResultsPOI.csv'
+    elif format == 'kml':
+        r['Content-Disposition'] = 'filename=SearchResults.kml'
 
     return r
 


### PR DESCRIPTION
this is how the bmlt root server outputs kml. it makes sense as its super annoying to have kml outputted to browser and not file.

https://github.com/LittleGreenViper/BMLT-Root-Server/blob/b4cd2eab6f7fa134557d30b8a481d0cf3f9e8b9f/main_server/client_interface/kml/index.php#L55-L66